### PR TITLE
Add acf drag and drop sorting support for manual query posts

### DIFF
--- a/assets/js/post-list-field.js
+++ b/assets/js/post-list-field.js
@@ -206,6 +206,11 @@
 		 * Store the index of the row as it's being dragged
 		 */
 		acf.addAction( 'sortstart', function( $el ) {
+			// Skip if this is not an ACF post list field
+			if ( $el.closest( '.acf-field-tribe-post-list' ).length === 0 ) {
+				return;
+			}
+
 			state.oldRowIndex = $el.index();
 		} );
 
@@ -213,8 +218,17 @@
 		 * Move the position of the dragged row
 		 */
 		acf.addAction( 'sortstop', function( $el ) {
+			// Skip if this is not an ACF post list field
+			if ( $el.closest( '.acf-field-tribe-post-list' ).length === 0 ) {
+				return;
+			}
+
 			const index = $el.index();
 			let fieldData = getFieldData( $el );
+			if ( !fieldData.manual_query.length ) {
+				return;
+			}
+
 			const old = fieldData.manual_query.splice( state.oldRowIndex, 1 );
 			fieldData.manual_query.splice( index, 0, old.shift() );
 			saveFieldData( fieldData, $el );

--- a/src/Post_List_Field.php
+++ b/src/Post_List_Field.php
@@ -240,7 +240,7 @@ class Post_List_Field extends acf_field {
 			return $value;
 		}
 
-		if ( self::OPTION_QUERY_TYPE_AUTO === $value[ self::FIELD_QUERY_TYPE ] ) {
+		if ( self::OPTION_QUERY_TYPE_AUTO === ( $value[ self::FIELD_QUERY_TYPE ] ?? '' ) ) {
 			return $this->get_posts_from_query( $value );
 		}
 


### PR DESCRIPTION
When a user used ACF's drag and drop to reorder manual query posts, their order was never saved. This fixes it by reordering that data in our JSON object.

I'll bump the version after its merged.