### PR TITLE
Allow Button Label to change via field registration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "moderntribe/tribe-acf-post-list-field",
   "description": "A post list field type for Advanced Custom Fields",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "type": "wordpress-plugin",
   "authors": [
     {

--- a/src/Post_List_Field.php
+++ b/src/Post_List_Field.php
@@ -34,6 +34,7 @@ class Post_List_Field extends acf_field {
 
 	// Manual Options
 	public const OPTION_ALLOW_OVERRIDE = 'allow_override';
+	public const OPTION_BUTTON_LABEL   = 'button_label';
 
 	// Rendered Options
 	public const FIELD_QUERY_TYPE         = 'query_type';
@@ -92,6 +93,7 @@ class Post_List_Field extends acf_field {
 			self::SETTINGS_FIELD_POST_TYPES_ALLOWED_MANUAL => [],
 			self::SETTINGS_FIELD_TAXONOMIES_ALLOWED        => [],
 			self::OPTION_ALLOW_OVERRIDE                    => true,
+			self::OPTION_BUTTON_LABEL                      => __( 'Add Row', 'tribe' ),
 			self::FIELD_QUERY_LIMIT                        => 5,
 			self::FIELD_QUERY_TYPE                         => self::OPTION_QUERY_TYPE_AUTO,
 			self::FIELD_QUERY_TERMS                        => [],
@@ -521,6 +523,7 @@ class Post_List_Field extends acf_field {
 			'name'              => self::FIELD_MANUAL_QUERY,
 			'key'               => self::FIELD_MANUAL_QUERY,
 			'label'             => __( 'Manual Items', 'tribe' ),
+			'button_label'      => $field[ self::OPTION_BUTTON_LABEL ] ?? $this->defaults[ self::OPTION_BUTTON_LABEL ],
 			'type'              => 'repeater',
 			'value'             => $field['value'][ self::FIELD_MANUAL_QUERY ] ?? $field[ self::FIELD_MANUAL_QUERY ] ?? [],
 			'conditional_logic' => [

--- a/tribe-acf-post-list-field.php
+++ b/tribe-acf-post-list-field.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: Tribe Post List Field
 Plugin URI: https://tri.be
 Description: A post list field type for advanced custom fields
-Version: 2.2.0
+Version: 2.2.1
 Author: Modern Tribe
 Author URI: https://tri.be
 */
@@ -32,7 +32,7 @@ require_once $autoload;
 function tribe_acf_post_list(): void {
 
 	$settings = [
-		'version' => '2.2.0',
+		'version' => '2.2.1',
 		'url'     => plugin_dir_url( __FILE__ ),
 		'path'    => plugin_dir_path( __FILE__ ),
 	];


### PR DESCRIPTION
Allows the field registrations to define the label for the "Add Row" button when the manual option is selected. Example:
```
new Field( self::NAME . '_' . self::POST_LIST, [
	'label'             => __( 'Post List', 'tribe' ),
	'name'              => self::POST_LIST,
	'type'              => 'tribe_post_list',
	'available_types'   => 'both',
	'button_label'      => __( 'Add Card', 'tribe' ), // <-- Override default "Add Row" label. 
	...
] );
