### PR TITLE
Bugfix/undefined index slider limit

### DIFF
--- a/src/Post_List_Field.php
+++ b/src/Post_List_Field.php
@@ -282,7 +282,7 @@ class Post_List_Field extends acf_field {
 			$item = [];
 
 			// No post and no override/custom
-			if ( empty( $row[ self::FIELD_MANUAL_POST ] ) && empty( $row[ self::FIELD_MANUAL_TOGGLE ] ) ) {
+			if ( empty( $row[ self::FIELD_MANUAL_POST ] ) || empty( $row[ self::FIELD_MANUAL_TOGGLE ] ) ) {
 				continue;
 			}
 

--- a/src/Post_List_Field.php
+++ b/src/Post_List_Field.php
@@ -1,4 +1,4 @@
-<?php declare( strict_types=1 );
+<?php declare(strict_types=1);
 
 namespace Tribe\ACF_Post_List;
 
@@ -80,7 +80,7 @@ class Post_List_Field extends acf_field {
 		$this->settings = $settings;
 	}
 
-	public function initialize() {
+	public function initialize(): void {
 		parent::initialize();
 		$this->name     = self::NAME;
 		$this->label    = __( 'Tribe Post List', 'tribe' );
@@ -265,6 +265,8 @@ class Post_List_Field extends acf_field {
 	/**
 	 * Returns posts selected by the user.
 	 *
+	 * @param $value
+	 *
 	 * @return array
 	 */
 	private function get_manually_selected_posts( $value ): array {
@@ -279,11 +281,12 @@ class Post_List_Field extends acf_field {
 		foreach ( $manual_rows as $row ) {
 			$item = [];
 
-			if ( ! $row[ self::FIELD_MANUAL_POST ] && ! $row[ self::FIELD_MANUAL_TOGGLE ] ) {
-				continue; //no post and no override/custom
+			// No post and no override/custom
+			if ( empty( $row[ self::FIELD_MANUAL_POST ] ) && empty( $row[ self::FIELD_MANUAL_TOGGLE ] ) ) {
+				continue;
 			}
 
-			//Get manually selected post
+			// Get manually selected post
 			if ( $row[ self::FIELD_MANUAL_POST ] ) {
 				$manual_post = get_post( $row[ self::FIELD_MANUAL_POST ] );
 
@@ -294,12 +297,12 @@ class Post_List_Field extends acf_field {
 				$item = $this->format_post( $manual_post );
 			}
 
-			//build custom or overwrite selected post above
+			// Build custom or overwrite selected post above
 			if ( $row[ self::FIELD_MANUAL_TOGGLE ] ) {
 				$item = $this->maybe_overwrite_values( $row, $item );
 			}
 
-			//Check if we have data for this post to remove any empty rows
+			// Check if we have data for this post to remove any empty rows
 			if ( ! $item || ! $this->is_valid_post( $item ) ) {
 				continue;
 			}
@@ -615,10 +618,10 @@ class Post_List_Field extends acf_field {
 							'value'    => '1',
 						],
 						[
-							'field' => self::FIELD_MANUAL_LINK_TOGGLE,
+							'field'    => self::FIELD_MANUAL_LINK_TOGGLE,
 							'operator' => '!=',
-							'value' => '1'
-						]
+							'value'    => '1',
+						],
 					],
 				],
 				[

--- a/src/Post_List_Field.php
+++ b/src/Post_List_Field.php
@@ -365,6 +365,12 @@ class Post_List_Field extends acf_field {
 	private function get_posts_from_query( $value ): array {
 		$post_types = (array) ( $value[ self::FIELD_QUERY_POST_TYPES ] ?? [] ) ?: ( $value[ self::SETTINGS_FIELD_POST_TYPES_ALLOWED ] ?? [] );
 		$tax_query  = $this->get_tax_query_args( $value );
+		$limit      = $value[ self::FIELD_QUERY_LIMIT ] ?? self::SETTINGS_FIELD_LIMIT_MIN;
+
+		// Allow user to select no posts.
+		if ( 0 === (int) $limit ) {
+			return [];
+		}
 
 		$args = [
 			'post_type'      => $post_types,
@@ -372,7 +378,7 @@ class Post_List_Field extends acf_field {
 				'relation' => 'AND',
 			],
 			'post_status'    => 'publish',
-			'posts_per_page' => $value[ self::FIELD_QUERY_LIMIT ] ?? self::SETTINGS_FIELD_LIMIT_MIN,
+			'posts_per_page' => $limit,
 		];
 
 		foreach ( $tax_query as $taxonomy => $ids ) {


### PR DESCRIPTION
- Fixes undefined index when using manual posts.
- Now properly merges default data with field data so limits/post types etc can be used when the block is initially added and all its values are empty. You can now pass `query_limit` via the block config and that will only allow a maximum number of posts for both dynamic and manual posts. 
- Allow users to select no posts to display ($limit = 0)

Example:

```php
new Field( self::NAME . '_' . self::POST_LIST, [
					'label'             => __( 'Posts', 'tribe' ),
					'name'              => self::POST_LIST,
					'type'              => 'tribe_post_list',
					'available_types'   => 'both',
					'post_types'        => [
						Post::NAME,
					],
					'post_types_manual' => [
						Post::NAME,
					],
					'taxonomies'        => [
						Post_Tag::NAME,
						Category::NAME,
					],
					'limit_min'         => 0,
					'limit_max'         => 3,
					'query_limit'       => 3,
				] );
```
