### PR TITLE
Bugfix/manual post saving without a picked post

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "moderntribe/tribe-acf-post-list-field",
   "description": "A post list field type for Advanced Custom Fields",
-  "version": "2.2.2",
   "type": "wordpress-plugin",
   "authors": [
     {

--- a/src/Post_List_Field.php
+++ b/src/Post_List_Field.php
@@ -285,7 +285,7 @@ class Post_List_Field extends acf_field {
 			$item = [];
 
 			// No post and no override/custom
-			if ( empty( $row[ self::FIELD_MANUAL_POST ] ) && empty( $row[ self::FIELD_MANUAL_TOGGLE ] ) ) {
+			if ( empty( $row[ self::FIELD_MANUAL_POST ] ) || empty( $row[ self::FIELD_MANUAL_TOGGLE ] ) ) {
 				continue;
 			}
 
@@ -570,6 +570,12 @@ class Post_List_Field extends acf_field {
 					'name'         => self::FIELD_MANUAL_TOGGLE,
 					'key'          => self::FIELD_MANUAL_TOGGLE,
 					'type'         => 'true_false',
+					'conditional_logic' => [
+						[
+							'field'    => self::FIELD_MANUAL_POST,
+							'operator' => '!=empty',
+						],
+					],
 				],
 				[
 					'label'             => __( 'Title', 'tribe' ),

--- a/tribe-acf-post-list-field.php
+++ b/tribe-acf-post-list-field.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: Tribe Post List Field
 Plugin URI: https://tri.be
 Description: A post list field type for advanced custom fields
-Version: 2.2.2
+Version: 2.2.3
 Author: Modern Tribe
 Author URI: https://tri.be
 */
@@ -32,7 +32,7 @@ require_once $autoload;
 function tribe_acf_post_list(): void {
 
 	$settings = [
-		'version' => '2.2.2',
+		'version' => '2.2.3',
 		'url'     => plugin_dir_url( __FILE__ ),
 		'path'    => plugin_dir_path( __FILE__ ),
 	];


### PR DESCRIPTION
- Hide all extra manual post repeater options until a user has picked a post, since we need a post to customize any of the data.
- Fix critical error on save if a user did not pick anything.