### PR TITLE
Bugfix/quotes in fields

### DIFF
--- a/assets/css/post-list-field.css
+++ b/assets/css/post-list-field.css
@@ -1,5 +1,16 @@
 .auto-query-row {
-    padding: 16px 20px;
-    border: #ccd0d4 solid 1px;
-    margin:-1px 5px 0;
+	padding: 16px 20px;
+	border: #ccd0d4 solid 1px;
+	margin: -1px 5px 0;
+}
+
+/*
+    Adding a row in the repeater via the + sign causes field order to
+    get messed up and also overwrites existing block data since the
+    indexes become shared.
+
+    Disable for now until we can figure out a better solution.
+ */
+.acf-field-manual-query .acf-repeater .acf-row-handle .acf-icon.-plus {
+	display: none !important;
 }

--- a/src/Post_List_Field.php
+++ b/src/Post_List_Field.php
@@ -261,7 +261,12 @@ class Post_List_Field extends acf_field {
 	 * @return mixed
 	 */
 	public function update_value( $data, $post_id, $field ) {
-		return json_decode( wp_unslash( $data ), true );
+		// WordPress runs wp_slash() on this data on auto save but ACF does not via ajax calls
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			$data = wp_unslash( $data );
+		}
+
+		return json_decode( $data, true );
 	}
 
 	/**

--- a/tribe-acf-post-list-field.php
+++ b/tribe-acf-post-list-field.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: Tribe Post List Field
 Plugin URI: https://tri.be
 Description: A post list field type for advanced custom fields
-Version: 2.2.5
+Version: 2.2.6
 Author: Modern Tribe
 Author URI: https://tri.be
 */
@@ -32,7 +32,7 @@ require_once $autoload;
 function tribe_acf_post_list(): void {
 
 	$settings = [
-		'version' => '2.2.5',
+		'version' => '2.2.6',
 		'url'     => plugin_dir_url( __FILE__ ),
 		'path'    => plugin_dir_path( __FILE__ ),
 	];


### PR DESCRIPTION
- [CHANGED]: Using the + sign on repeater rows causes our data to get all messed up because it has a chance to replace an existing index and we have no context of whether we should replace data or replace an existing index and move that old data up one index. Hide the button for now until things slow down and we can look at this in more detail.
- [FIXED]: Allow double quotes `"` to be entered into text fields. Depending on the context of when a block is being updated, data can be slashed or not slashed...
