### PR TITLE
Fix/acf nonce check for tax field render

### DIFF
--- a/src/Multiple_Taxonomy_Field.php
+++ b/src/Multiple_Taxonomy_Field.php
@@ -169,18 +169,22 @@ class Multiple_Taxonomy_Field extends acf_field_taxonomy {
 		$field['value']    = acf_get_array( $field['value'] );
 		$field['multiple'] = 0;
 
+		$nonce = wp_create_nonce( 'acf_field_' . $this->name . '_' . $field['key'] );
+
 		// Vars.
 		$div = [
 			'class'           => 'acf-taxonomy-field acf-soh',
 			'data-save'       => $field['save_terms'],
 			'data-type'       => $field['field_type'],
 			'data-taxonomies' => $field['taxonomies'],
+			'data-allow_null' => $field['allow_null'],
 			'data-ftype'      => 'select',
+			'data-nonce'      => $nonce,
 		];
 
 		?>
         <div <?php acf_esc_attrs( $div ); ?>>
-			<?php $this->render_field_select( $field ); ?>
+			<?php $this->render_field_select( $field, $nonce ); ?>
         </div>
 		<?php
 	}
@@ -190,8 +194,9 @@ class Multiple_Taxonomy_Field extends acf_field_taxonomy {
 	 * Render the taxonomy select field.
 	 *
 	 * @param  array  $field
+	 * @param string $nonce
 	 */
-	public function render_field_select( $field ): void {
+	public function render_field_select( $field, $nonce ): void {
 
 		// Change Field into a select.
 		$field['type']     = 'select';
@@ -199,6 +204,7 @@ class Multiple_Taxonomy_Field extends acf_field_taxonomy {
 		$field['ajax']     = 1;
 		$field['multiple'] = 1;
 		$field['choices']  = [];
+		$field['nonce']    = $nonce;
 
 		$choices = [];
 

--- a/tribe-acf-post-list-field.php
+++ b/tribe-acf-post-list-field.php
@@ -4,7 +4,7 @@
 Plugin Name: Advanced Custom Fields: Tribe Post List Field
 Plugin URI: https://tri.be
 Description: A post list field type for advanced custom fields
-Version: 2.2.8
+Version: 2.2.10
 Author: Modern Tribe
 Author URI: https://tri.be
 */
@@ -32,7 +32,7 @@ require_once $autoload;
 function tribe_acf_post_list(): void {
 
 	$settings = [
-		'version' => '2.2.7',
+		'version' => '2.2.10',
 		'url'     => plugin_dir_url( __FILE__ ),
 		'path'    => plugin_dir_path( __FILE__ ),
 	];


### PR DESCRIPTION
Per a fatal error discovered with recent versions of ACF Pro discovered on Data.org, update the signature for our `render_field_select()` override function to match.

Fatal error:
`Fatal error: Declaration of Tribe\ACF_Post_List\Multiple_Taxonomy_Field::render_field_select($field): void must be compatible with acf_field_taxonomy::render_field_select($field, $nonce) in /code/wp-content/plugins/tribe-acf-post-list-field/src/Multiple_Taxonomy_Field.php on line 194`